### PR TITLE
fix: see error message in failing job

### DIFF
--- a/walls.py
+++ b/walls.py
@@ -75,9 +75,13 @@ class SalesforceConnection(object):
         }
         token_path = "/services/oauth2/token"
         url = "{0}://{1}{2}".format("https", SALESFORCE["HOST"], token_path)
-        # TODO: some error handling here:
         r = requests.post(url, data=payload)
         response = json.loads(r.text)
+        if r.status_code != 200 or "instance_url" not in response:
+            raise RuntimeError(
+                "Salesforce OAuth2 token request failed: "
+                "status={}, body={}".format(r.status_code, response)
+            )
         self.instance_url = response["instance_url"]
         access_token = response["access_token"]
 


### PR DESCRIPTION
## Summary
Adds an error message where [this job](https://github.com/texastribune/cron-jobs/actions/runs/25180447119/job/73823968004) is failing.


## Test Steps

1. Run `make test` — suite should pass
2. To verify the error path: temporarily set a bad `SALESFORCE_PASSWORD` in the `env`
   file, run `make run`, and confirm the log output includes the status code and response
   body instead of a bare `KeyError`
3. Restore correct credentials and confirm `make run` succeeds end-to-end
