### PR TITLE
fix: pin numpy version and update docker-compose format

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
-walls:
-  image: texastribune/walls
-  volumes:
-    - ./:/app
-  env_file:
-    - ./env
-  working_dir: /app
-  command: python walls.py
+services:
+  walls:
+    image: texastribune/walls
+    volumes:
+      - ./:/app
+    env_file:
+      - ./env
+    working_dir: /app
+    command: python walls.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 salesforce-bulk==2.1.0
 pandas==1.4.0
+numpy<2.0
 simple-salesforce==0.74.3
 boto3==1.11.1
 #ipdb
-#pytest
+pytest


### PR DESCRIPTION
## Summary

Fixes two issues preventing the cron job from running: a numpy/pandas binary incompatibility that crashed on import, and an outdated docker-compose format.

## Why the image needs to be rebuilt manually

The Docker Hub image was previously pushed from my new (Silicon) mac, which produced an arm64-only image. The GitHub Actions runner is `linux/amd64`, so it failed with "no matching manifest for linux/amd64" when pulling. The fix is to rebuild using `docker buildx` with `--platform linux/amd64` to produce an image the CI runner can use.

## Test Steps

1. Build the image targeting linux/amd64 (prior push was built on an Apple Silicon Mac and only had an arm64 manifest, which caused the CI runner to fail): `docker buildx build --platform linux/amd64 -t texastribune/walls:latest --push .`
2. Trigger the GitHub Actions cron job manually
3. Confirm the "Run Walls Job" step no longer fails with `ValueError: numpy.dtype size changed`
