### PR TITLE
fix: try removing token auth

### DIFF
--- a/walls.py
+++ b/walls.py
@@ -170,7 +170,7 @@ def sf_data(query):
     TOKEN = SALESFORCE["TOKEN"]
     HOST = SALESFORCE["HOST"]
 
-    sf = Salesforce(username=USER, password=PASS, security_token=TOKEN)
+    sf = Salesforce(username=USER, password=PASS, security_token="")
 
     bulk = SalesforceBulk(sessionId=sf.session_id, host=HOST)
 


### PR DESCRIPTION
## Summary

Remove the Salesforce security token from the `simple_salesforce` Bulk API auth, mirroring the fix applied to the OAuth path in #889.

## Context

The job was failing with `SalesforceAuthenticationFailed: INVALID_LOGIN` on the Bulk API path (`sf_data`). PR #889 fixed the same issue for the `SalesforceConnection` OAuth path by not appending the security token to the password — the assumption being that the Actions runner IP is whitelisted in Salesforce and the token isn't needed.

`simple_salesforce` was still passing the token as a separate parameter, which it internally appends to the password. This PR applies the same fix to that path.

## Test Steps

1. Merge and run `docker buildx build --platform linux/amd64 -t texastribune/walls:latest --push .` to push to docker
2. let the scheduled job run (or trigger it manually)
3. Confirm job completes without `SalesforceAuthenticationFailed`
4. Confirm all four output files (`circle-members.json`, `sponsors.json`, `business-member-roster.json`, `donors.json`) are updated in S3