### PR TITLE
feat: per-newsroom sponsor and donor S3 outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,11 @@ interactive: build
 		--rm --interactive --tty \
 		--entrypoint=bash \
 		--name=${APP} ${NS}/${APP}
+
+# Build and push the production image. Forces linux/amd64 because the
+# production cron runner is x86; on Apple Silicon a plain `docker push`
+# would upload an arm64 image and silently break the next cron run.
+push:
+	docker buildx build --platform linux/amd64 \
+		--tag=${NS}/${APP}:latest \
+		--push .

--- a/convert.py
+++ b/convert.py
@@ -242,6 +242,80 @@ def convert_donors(accounts, opportunities):
     return export
 
 
+def convert_donors_per_newsroom_over_1k(opportunities, accounts):
+    """
+    Aggregate Membership-only donor opportunities into a unified per-newsroom
+    file. A donor qualifies if their per-newsroom total is >= $1,000 in at
+    least one newsroom (Texas Tribune, Austin, or Waco Bridge).
+
+    Returns a JSON string with shape:
+        {metadata: {generated_at, threshold, donor_record_types, newsrooms},
+         donors: [{attribution, qualifying_newsrooms, totals_by_newsroom}]}
+    """
+    NEWSROOMS = ("Texas Tribune", "Austin", "Waco Bridge")
+    THRESHOLD = 1000
+
+    opportunities["Amount"] = pd.to_numeric(opportunities["Amount"], errors="coerce")
+    opportunities = opportunities.dropna(subset=["Amount"])
+    opportunities = opportunities[opportunities["AccountId"] != ""]
+
+    # Belt-and-suspenders against SOQL drift / new picklist values
+    opportunities = opportunities[opportunities["Newsroom__c"].isin(NEWSROOMS)]
+
+    # sum opportunity amounts per account per newsroom
+    subtotals = (
+        opportunities.groupby(["AccountId", "Newsroom__c"])["Amount"]
+        .sum()
+        .reset_index()
+    )
+    # reorganize to one row per account with a column for each newsroom's
+    # total, including newsrooms with no giving
+    acct_totals_by_newsroom = (
+        subtotals.pivot(index="AccountId", columns="Newsroom__c", values="Amount")
+        .fillna(0)
+        .reindex(columns=list(NEWSROOMS), fill_value=0)
+    )
+    qualifying = acct_totals_by_newsroom[
+        (acct_totals_by_newsroom >= THRESHOLD).any(axis=1)
+    ]
+
+    accounts_dict = accounts.set_index("AccountId")["Text_For_Donor_Wall__c"].to_dict()
+
+    # check for 'Type' column
+    if "Type" in accounts.columns:
+        type_dict = accounts.set_index("AccountId")["Type"].to_dict()
+    else:
+        type_dict = {}
+
+    donors = []
+    for accountid, row in qualifying.iterrows():
+        raw_attribution = accounts_dict.get(accountid)
+        attribution = None if pd.isna(raw_attribution) else raw_attribution
+        donors.append(
+            {
+                "attribution": attribution,
+                "account_type": _safe_account_type(type_dict.get(accountid)),
+                "qualifying_newsrooms": [n for n in NEWSROOMS if row[n] >= THRESHOLD],
+                "totals_by_newsroom": {n: _round_to_int(row[n]) for n in NEWSROOMS},
+            }
+        )
+
+    donors.sort(
+        key=lambda d: (d["attribution"] is None, (d["attribution"] or "").lower())
+    )
+
+    final = {
+        "metadata": {
+            "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "threshold": THRESHOLD,
+            "donor_record_types": ["Membership"],
+            "newsrooms": list(NEWSROOMS),
+        },
+        "donors": donors,
+    }
+    return json.dumps(final)
+
+
 def _extract_and_map(argument=None, key=None, value=None, sort_key=None):
     """
     Transform a list with dictionaries like this:
@@ -311,81 +385,14 @@ def _strip_sort_key(the_dict):
     return new_dict
 
 
-def convert_donors_per_newsroom_over_1k(opportunities, accounts):
-    """
-    Aggregate Membership-only donor opportunities into a unified per-newsroom
-    file. A donor qualifies if their per-newsroom total is >= $1,000 in at
-    least one newsroom (Texas Tribune, Austin, or Waco Bridge).
+def _round_to_int(amount):
+    return int(Decimal(str(amount)).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
 
-    Returns a JSON string with shape:
-        {metadata: {generated_at, threshold, donor_record_types, newsrooms},
-         donors: [{attribution, qualifying_newsrooms, totals_by_newsroom}]}
-    """
-    NEWSROOMS = ("Texas Tribune", "Austin", "Waco Bridge")
 
-    opportunities["Amount"] = pd.to_numeric(opportunities["Amount"], errors="coerce")
-    opportunities = opportunities.dropna(subset=["Amount"])
-    opportunities = opportunities[opportunities["AccountId"] != ""]
-
-    # Belt-and-suspenders against SOQL drift / new picklist values
-    opportunities = opportunities[opportunities["Newsroom__c"].isin(NEWSROOMS)]
-
-    subtotals = (
-        opportunities.groupby(["AccountId", "Newsroom__c"])["Amount"]
-        .sum()
-        .reset_index()
-    )
-    wide = (
-        subtotals.pivot(index="AccountId", columns="Newsroom__c", values="Amount")
-        .fillna(0)
-        .reindex(columns=list(NEWSROOMS), fill_value=0)
-    )
-    qualifying = wide[(wide >= 1000).any(axis=1)]
-
-    accounts_dict = accounts.set_index("AccountId")["Text_For_Donor_Wall__c"].to_dict()
-
-    # Account.Type drives the entity_type classification downstream (CF1.8).
-    # Defensive: tolerate fixtures or SOQL drift where the column is absent.
-    if "Type" in accounts.columns:
-        type_dict = accounts.set_index("AccountId")["Type"].to_dict()
-    else:
-        type_dict = {}
-
-    def _round_to_int(amount):
-        return int(Decimal(str(amount)).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
-
-    def _safe_account_type(value):
-        if value is None or pd.isna(value) or value == "":
-            return None
-        return value
-
-    donors = []
-    for accountid, row in qualifying.iterrows():
-        raw_attribution = accounts_dict.get(accountid)
-        attribution = None if pd.isna(raw_attribution) else raw_attribution
-        donors.append(
-            {
-                "attribution": attribution,
-                "account_type": _safe_account_type(type_dict.get(accountid)),
-                "qualifying_newsrooms": [n for n in NEWSROOMS if row[n] >= 1000],
-                "totals_by_newsroom": {n: _round_to_int(row[n]) for n in NEWSROOMS},
-            }
-        )
-
-    donors.sort(
-        key=lambda d: (d["attribution"] is None, (d["attribution"] or "").lower())
-    )
-
-    final = {
-        "metadata": {
-            "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "threshold": 1000,
-            "donor_record_types": ["Membership"],
-            "newsrooms": list(NEWSROOMS),
-        },
-        "donors": donors,
-    }
-    return json.dumps(final)
+def _safe_account_type(value):
+    if value is None or pd.isna(value) or value == "":
+        return None
+    return value
 
 
 if __name__ == "__main__":

--- a/convert.py
+++ b/convert.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timezone
 from decimal import ROUND_HALF_UP, Decimal
 
 import pandas as pd
@@ -308,6 +309,70 @@ def _strip_sort_key(the_dict):
             new_list.append(tup[2])
         new_dict[k] = new_list
     return new_dict
+
+
+def convert_donors_per_newsroom_over_1k(opportunities, accounts):
+    """
+    Aggregate Membership-only donor opportunities into a unified per-newsroom
+    file. A donor qualifies if their per-newsroom total is >= $1,000 in at
+    least one newsroom (Texas Tribune, Austin, or Waco Bridge).
+
+    Returns a JSON string with shape:
+        {metadata: {generated_at, threshold, donor_record_types, newsrooms},
+         donors: [{attribution, qualifying_newsrooms, totals_by_newsroom}]}
+    """
+    NEWSROOMS = ("Texas Tribune", "Austin", "Waco Bridge")
+
+    opportunities["Amount"] = pd.to_numeric(opportunities["Amount"], errors="coerce")
+    opportunities = opportunities.dropna(subset=["Amount"])
+    opportunities = opportunities[opportunities["AccountId"] != ""]
+
+    # Belt-and-suspenders against SOQL drift / new picklist values
+    opportunities = opportunities[opportunities["Newsroom__c"].isin(NEWSROOMS)]
+
+    subtotals = (
+        opportunities.groupby(["AccountId", "Newsroom__c"])["Amount"]
+        .sum()
+        .reset_index()
+    )
+    wide = (
+        subtotals.pivot(index="AccountId", columns="Newsroom__c", values="Amount")
+        .fillna(0)
+        .reindex(columns=list(NEWSROOMS), fill_value=0)
+    )
+    qualifying = wide[(wide >= 1000).any(axis=1)]
+
+    accounts_dict = accounts.set_index("AccountId")["Text_For_Donor_Wall__c"].to_dict()
+
+    def _round_to_int(amount):
+        return int(Decimal(str(amount)).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+    donors = []
+    for accountid, row in qualifying.iterrows():
+        raw_attribution = accounts_dict.get(accountid)
+        attribution = None if pd.isna(raw_attribution) else raw_attribution
+        donors.append(
+            {
+                "attribution": attribution,
+                "qualifying_newsrooms": [n for n in NEWSROOMS if row[n] >= 1000],
+                "totals_by_newsroom": {n: _round_to_int(row[n]) for n in NEWSROOMS},
+            }
+        )
+
+    donors.sort(
+        key=lambda d: (d["attribution"] is None, (d["attribution"] or "").lower())
+    )
+
+    final = {
+        "metadata": {
+            "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "threshold": 1000,
+            "donor_record_types": ["Membership"],
+            "newsrooms": list(NEWSROOMS),
+        },
+        "donors": donors,
+    }
+    return json.dumps(final)
 
 
 if __name__ == "__main__":

--- a/convert.py
+++ b/convert.py
@@ -344,8 +344,20 @@ def convert_donors_per_newsroom_over_1k(opportunities, accounts):
 
     accounts_dict = accounts.set_index("AccountId")["Text_For_Donor_Wall__c"].to_dict()
 
+    # Account.Type drives the entity_type classification downstream (CF1.8).
+    # Defensive: tolerate fixtures or SOQL drift where the column is absent.
+    if "Type" in accounts.columns:
+        type_dict = accounts.set_index("AccountId")["Type"].to_dict()
+    else:
+        type_dict = {}
+
     def _round_to_int(amount):
         return int(Decimal(str(amount)).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+    def _safe_account_type(value):
+        if value is None or pd.isna(value) or value == "":
+            return None
+        return value
 
     donors = []
     for accountid, row in qualifying.iterrows():
@@ -354,6 +366,7 @@ def convert_donors_per_newsroom_over_1k(opportunities, accounts):
         donors.append(
             {
                 "attribution": attribution,
+                "account_type": _safe_account_type(type_dict.get(accountid)),
                 "qualifying_newsrooms": [n for n in NEWSROOMS if row[n] >= 1000],
                 "totals_by_newsroom": {n: _round_to_int(row[n]) for n in NEWSROOMS},
             }

--- a/tests.py
+++ b/tests.py
@@ -712,3 +712,68 @@ def test_convert_donors_per_newsroom_over_1k_metadata_block():
     assert metadata["newsrooms"] == ["Texas Tribune", "Austin", "Waco Bridge"]
     assert metadata["generated_at"].endswith("Z")
     assert len(metadata["generated_at"]) == 20  # YYYY-MM-DDTHH:MM:SSZ
+
+
+def test_convert_donors_per_newsroom_over_1k_account_type_passthrough():
+    """
+    Account.Type flows through to each donor entry as `account_type`
+    (raw SF value). Step 2 will map this to entity_type per CF1.8.
+    """
+    opportunities = DataFrame(
+        {
+            "AccountId":   ["A1",            "A2",            "A3",            "A4"],
+            "Amount":      [1000.0,          1000.0,          1000.0,          1000.0],
+            "Newsroom__c": ["Texas Tribune", "Texas Tribune", "Texas Tribune", "Texas Tribune"],
+            "CloseDate":   ["2025-03-01"] * 4,
+        }
+    )
+    accounts = DataFrame(
+        {
+            "AccountId": ["A1", "A2", "A3", "A4"],
+            "Text_For_Donor_Wall__c": ["Donor A1", "Donor A2", "Donor A3", "Donor A4"],
+            "Type": ["Household", "Foundation", "Corporate", "Association"],
+        }
+    )
+    actual = json.loads(convert_donors_per_newsroom_over_1k(opportunities, accounts))
+    by_attr = {d["attribution"]: d for d in actual["donors"]}
+    assert by_attr["Donor A1"]["account_type"] == "Household"
+    assert by_attr["Donor A2"]["account_type"] == "Foundation"
+    assert by_attr["Donor A3"]["account_type"] == "Corporate"
+    assert by_attr["Donor A4"]["account_type"] == "Association"
+
+
+def test_convert_donors_per_newsroom_over_1k_account_type_missing_or_empty():
+    """
+    When the Type column is absent (e.g., older fixtures or SOQL drift) or
+    contains an empty string, account_type is None. Step 2 will default
+    null to 'organization' per CF1.8 §3.
+    """
+    opportunities = DataFrame(
+        {
+            "AccountId":   ["A1"],
+            "Amount":      [1000.0],
+            "Newsroom__c": ["Texas Tribune"],
+            "CloseDate":   ["2025-03-01"],
+        }
+    )
+
+    # No Type column at all
+    accounts_no_col = DataFrame(
+        {
+            "AccountId": ["A1"],
+            "Text_For_Donor_Wall__c": ["Donor A1"],
+        }
+    )
+    actual = json.loads(convert_donors_per_newsroom_over_1k(opportunities, accounts_no_col))
+    assert actual["donors"][0]["account_type"] is None
+
+    # Type column present but empty string
+    accounts_empty = DataFrame(
+        {
+            "AccountId": ["A1"],
+            "Text_For_Donor_Wall__c": ["Donor A1"],
+            "Type": [""],
+        }
+    )
+    actual = json.loads(convert_donors_per_newsroom_over_1k(opportunities, accounts_empty))
+    assert actual["donors"][0]["account_type"] is None

--- a/tests.py
+++ b/tests.py
@@ -9,6 +9,7 @@ from convert import (
     _strip_sort_key,
     clean_url,
     convert_donors,
+    convert_donors_per_newsroom_over_1k,
     convert_sponsors,
     make_pretty_money,
 )
@@ -583,3 +584,131 @@ def test_clean_url():
     input = "http://"
     actual = clean_url(input)
     assert actual == ""
+
+
+def test_convert_donors_per_newsroom_over_1k_basic():
+    """
+    Comprehensive case covering threshold, multi-newsroom qualifying,
+    cumulative-cross-newsroom failure, and defensive filter.
+    """
+    opportunities = DataFrame(
+        {
+            "AccountId":   ["A1",            "A2",            "A3",            "A3",     "A4",            "A4",     "A5"],
+            "Amount":      [1000.0,          999.0,           1000.0,          1500.0,   500.0,           400.0,    1000.0],
+            "Newsroom__c": ["Texas Tribune", "Texas Tribune", "Texas Tribune", "Austin", "Texas Tribune", "Austin", "Bogus"],
+            "CloseDate":   ["2025-03-01"] * 7,
+        }
+    )
+    accounts = DataFrame(
+        {
+            "AccountId": ["A1", "A2", "A3", "A4", "A5"],
+            "Text_For_Donor_Wall__c": ["Donor A1", "Donor A2", "Donor A3", "Donor A4", "Donor A5"],
+        }
+    )
+    actual = json.loads(convert_donors_per_newsroom_over_1k(opportunities, accounts))
+
+    attributions = [d["attribution"] for d in actual["donors"]]
+    assert attributions == ["Donor A1", "Donor A3"]
+
+    a1 = next(d for d in actual["donors"] if d["attribution"] == "Donor A1")
+    assert a1["qualifying_newsrooms"] == ["Texas Tribune"]
+    assert a1["totals_by_newsroom"] == {"Texas Tribune": 1000, "Austin": 0, "Waco Bridge": 0}
+
+    a3 = next(d for d in actual["donors"] if d["attribution"] == "Donor A3")
+    assert a3["qualifying_newsrooms"] == ["Texas Tribune", "Austin"]
+    assert a3["totals_by_newsroom"] == {"Texas Tribune": 1000, "Austin": 1500, "Waco Bridge": 0}
+
+
+def test_convert_donors_per_newsroom_over_1k_below_threshold():
+    """
+    Donor with $500 Tribune + $400 Austin (cumulative $900) qualifies in
+    NEITHER newsroom — the threshold is per-newsroom, not cumulative.
+    """
+    opportunities = DataFrame(
+        {
+            "AccountId":   ["A1",            "A1"],
+            "Amount":      [500.0,           400.0],
+            "Newsroom__c": ["Texas Tribune", "Austin"],
+            "CloseDate":   ["2025-03-01"] * 2,
+        }
+    )
+    accounts = DataFrame(
+        {
+            "AccountId": ["A1"],
+            "Text_For_Donor_Wall__c": ["Donor A1"],
+        }
+    )
+    actual = json.loads(convert_donors_per_newsroom_over_1k(opportunities, accounts))
+    assert actual["donors"] == []
+
+
+def test_convert_donors_per_newsroom_over_1k_exact_threshold():
+    """
+    $1000 exactly qualifies; $999 does not.
+    """
+    opportunities = DataFrame(
+        {
+            "AccountId":   ["A1",            "A2"],
+            "Amount":      [1000.0,          999.0],
+            "Newsroom__c": ["Texas Tribune", "Texas Tribune"],
+            "CloseDate":   ["2025-03-01"] * 2,
+        }
+    )
+    accounts = DataFrame(
+        {
+            "AccountId": ["A1", "A2"],
+            "Text_For_Donor_Wall__c": ["Donor A1", "Donor A2"],
+        }
+    )
+    actual = json.loads(convert_donors_per_newsroom_over_1k(opportunities, accounts))
+    assert [d["attribution"] for d in actual["donors"]] == ["Donor A1"]
+
+
+def test_convert_donors_per_newsroom_over_1k_defensive_filter():
+    """
+    Row with Newsroom__c outside the canonical three (e.g., a new picklist
+    value or stale data) is silently dropped before aggregation.
+    """
+    opportunities = DataFrame(
+        {
+            "AccountId":   ["A1",            "A2"],
+            "Amount":      [1000.0,          1000.0],
+            "Newsroom__c": ["Texas Tribune", "Bogus"],
+            "CloseDate":   ["2025-03-01"] * 2,
+        }
+    )
+    accounts = DataFrame(
+        {
+            "AccountId": ["A1", "A2"],
+            "Text_For_Donor_Wall__c": ["Donor A1", "Donor A2"],
+        }
+    )
+    actual = json.loads(convert_donors_per_newsroom_over_1k(opportunities, accounts))
+    assert [d["attribution"] for d in actual["donors"]] == ["Donor A1"]
+
+
+def test_convert_donors_per_newsroom_over_1k_metadata_block():
+    """
+    Output's metadata block has the documented shape and values.
+    """
+    opportunities = DataFrame(
+        {
+            "AccountId":   ["A1"],
+            "Amount":      [1000.0],
+            "Newsroom__c": ["Texas Tribune"],
+            "CloseDate":   ["2025-03-01"],
+        }
+    )
+    accounts = DataFrame(
+        {
+            "AccountId": ["A1"],
+            "Text_For_Donor_Wall__c": ["Donor A1"],
+        }
+    )
+    actual = json.loads(convert_donors_per_newsroom_over_1k(opportunities, accounts))
+    metadata = actual["metadata"]
+    assert metadata["threshold"] == 1000
+    assert metadata["donor_record_types"] == ["Membership"]
+    assert metadata["newsrooms"] == ["Texas Tribune", "Austin", "Waco Bridge"]
+    assert metadata["generated_at"].endswith("Z")
+    assert len(metadata["generated_at"]) == 20  # YYYY-MM-DDTHH:MM:SSZ

--- a/walls.py
+++ b/walls.py
@@ -222,7 +222,7 @@ def sf_data(query):
     job = bulk.create_query_job("Account", contentType="CSV")
     print("Creating Account job...")
 
-    batch = bulk.query(job, "SELECT Id, Website, Text_For_Donor_Wall__c FROM Account")
+    batch = bulk.query(job, "SELECT Id, Website, Text_For_Donor_Wall__c, Type FROM Account")
     print("Issuing query...")
     while not bulk.is_batch_done(batch):
         print("waiting for query to complete...")

--- a/walls.py
+++ b/walls.py
@@ -275,15 +275,17 @@ print("Fetching per-newsroom sponsor data...")
 opps_pn, accts_pn = sf_data(sponsors_query_per_newsroom)
 
 for newsroom_value in ("Texas Tribune", "Austin", "Waco Bridge"):
+    # narrow the all-newsrooms result to this newsroom's opportunities
     partition = opps_pn[opps_pn["Newsroom__c"] == newsroom_value]
     file_slug = newsroom_value.lower().replace(" ", "-")
     print(f"Transforming {newsroom_value} sponsors ({len(partition)} rows)...")
     if partition.empty:
-        # convert_sponsors crashes on zero-row input (no Amount column to coerce)
-        json_output = json.dumps({})
-    else:
-        json_output = convert_sponsors(opportunities=partition, accounts=accts_pn)
-    push_to_s3(filename=f"per-newsroom/{file_slug}_sponsors.json", contents=json_output)
+        # Skip the push so a transient zero-row result can't clobber a previously
+        # good list. Embeddings Lambda tolerates missing input files.
+        print(f"  no rows for {newsroom_value} — skipping push")
+        continue
+    json_output = convert_sponsors(opportunities=partition, accounts=accts_pn)
+    push_to_s3(filename=f"per-newsroom/{file_slug}-sponsors.json", contents=json_output)
 
 # Per-newsroom donors (1 unified file, >=$1k per-newsroom threshold)
 print("Fetching per-newsroom donor data...")

--- a/walls.py
+++ b/walls.py
@@ -14,6 +14,7 @@ from convert import (
     _sort_circle,
     _strip_sort_key,
     convert_donors,
+    convert_donors_per_newsroom_over_1k,
     convert_sponsors,
 )
 from s3 import push_to_s3
@@ -53,6 +54,32 @@ circle_query = """
     AND Membership_Status__c = 'Current'
     ORDER BY Membership_Level_TT__c
 
+"""
+
+# Per-newsroom variant of sponsors_query — adds Newsroom__c to SELECT and filter
+sponsors_query_per_newsroom = """
+        SELECT Id, AccountId, Amount, CloseDate, Type, RecordTypeId, Newsroom__c
+        FROM Opportunity
+        WHERE RecordTypeId IN (
+            '01216000001IhmxAAC',
+            '01216000001IhIEAA0',
+            '01246000000hj93AAA',
+            '01216000001IhvaAAC'
+        )
+        AND StageName IN ('Closed Won', 'Invoiced', 'Pledged')
+        AND Type != 'Earned Revenue'
+        AND Amount != 0
+        AND Newsroom__c IN ('Texas Tribune', 'Austin', 'Waco Bridge')
+    """
+
+# Per-newsroom donors — Membership only; $1k threshold applied in Python post-query
+donors_query_membership_per_newsroom = """
+    SELECT Id, AccountId, Amount, CloseDate, RecordTypeId, Newsroom__c
+    FROM Opportunity
+    WHERE RecordTypeId = '01216000001IhHpAAK'
+    AND StageName IN ('Closed Won', 'Pledged')
+    AND Newsroom__c IN ('Texas Tribune', 'Austin', 'Waco Bridge')
+    AND Amount > 0
 """
 
 
@@ -242,3 +269,26 @@ json_output = convert_donors(opportunities=opps, accounts=accts)
 
 print("Saving donors to S3...")
 push_to_s3(filename="donors.json", contents=json_output)
+
+# Per-newsroom sponsors (3 files: texas-tribune, austin, waco-bridge)
+print("Fetching per-newsroom sponsor data...")
+opps_pn, accts_pn = sf_data(sponsors_query_per_newsroom)
+
+for newsroom_value in ("Texas Tribune", "Austin", "Waco Bridge"):
+    partition = opps_pn[opps_pn["Newsroom__c"] == newsroom_value]
+    file_slug = newsroom_value.lower().replace(" ", "-")
+    print(f"Transforming {newsroom_value} sponsors ({len(partition)} rows)...")
+    if partition.empty:
+        # convert_sponsors crashes on zero-row input (no Amount column to coerce)
+        json_output = json.dumps({})
+    else:
+        json_output = convert_sponsors(opportunities=partition, accounts=accts_pn)
+    push_to_s3(filename=f"per-newsroom/{file_slug}_sponsors.json", contents=json_output)
+
+# Per-newsroom donors (1 unified file, >=$1k per-newsroom threshold)
+print("Fetching per-newsroom donor data...")
+opps_pn, accts_pn = sf_data(donors_query_membership_per_newsroom)
+print("Transforming per-newsroom donors...")
+json_output = convert_donors_per_newsroom_over_1k(opportunities=opps_pn, accounts=accts_pn)
+print("Saving per-newsroom donors to S3...")
+push_to_s3(filename="per-newsroom/all-donors-per-newsroom-over-1k.json", contents=json_output)


### PR DESCRIPTION
## Summary

Extends `walls.py` to produce four new files under a new `per-newsroom/` prefix, in support of Austin Current and Waco Bridge if they want to launch the Yellow Lights plugin.

New outputs in S3:
- `per-newsroom/texas-tribune-sponsors.json`
- `per-newsroom/austin-sponsors.json`
- `per-newsroom/waco-bridge-sponsors.json`
- `per-newsroom/all-donors-per-newsroom-over-1k.json`

## Tests

- 19/19 unit tests pass (14 existing + 5 new for the per-newsroom donor aggregation)
- Local Docker build green
- **Not yet run end-to-end against SF sandbox + test S3.** Happy to do that before merge if you'd prefer — let me know.

## Deploy notes — arm64 gotcha

Production cron runs on x86. From an Apple Silicon Mac, a plain `docker push` after `make build` silently uploads an arm64 image and breaks the next cron run. Two paths:
- **Existing manual approach:** `docker buildx build --platform linux/amd64 -t texastribune/walls:latest --push .` after a master pull.
- **Optional convenience commit in this PR (`e988295`):** adds a `make push` target that wraps the buildx command. Feel free to drop the commit if you don't want it; the change is purely additive (no existing target's behavior changes).

## Rollback

Revert the PR, rebuild and push the previous image. Existing bucket-root files keep flowing; new files just go stale.