### PR TITLE
feat: qualify supporters by recent and lifetime giving tiers

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -1,4 +1,5 @@
 import json
+from collections import defaultdict
 from datetime import datetime, timezone
 from decimal import ROUND_HALF_UP, Decimal
 
@@ -242,19 +243,49 @@ def convert_donors(accounts, opportunities):
     return export
 
 
-def convert_donors_per_newsroom_over_1k(opportunities, accounts):
+def convert_qualified_supporters(donor_opps, sponsor_opps, accounts, as_of=None):
     """
-    Aggregate Membership-only donor opportunities into a unified per-newsroom
-    file. A donor qualifies if their per-newsroom total is >= $1,000 in at
-    least one newsroom (Texas Tribune, Austin, or Waco Bridge).
+    Aggregate donor and sponsor opportunities into one per-newsroom
+    qualification file, used by the Yellow Lights disclosure check. Compiles 
+    sponsors and donors based on whether they hit either or both of these tiers:
+
+        recent    >= $1,000 to that newsroom in the trailing 1,825 days
+        lifetime  >= $100,000 to that newsroom, all time
 
     Returns a JSON string with shape:
-        {metadata: {generated_at, threshold, donor_record_types, newsrooms},
-         donors: [{attribution, qualifying_newsrooms, totals_by_newsroom}]}
+        {metadata: {...},
+         supporters: [{attribution, source, account_type, tiers_by_newsroom}]}
     """
     NEWSROOMS = ("Texas Tribune", "Austin", "Waco Bridge")
-    THRESHOLD = 1000
+    WINDOW_DAYS = 1825
+    RECENT_THRESHOLD = 1000
+    LIFETIME_THRESHOLD = 100000
+    COLUMNS = ["AccountId", "Amount", "CloseDate", "Newsroom__c"]
 
+    final = {
+        "metadata": {
+            "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "window_days": WINDOW_DAYS,
+            "recent_threshold": RECENT_THRESHOLD,
+            "lifetime_threshold": LIFETIME_THRESHOLD,
+            "in_kind_included": True,
+            "donor_record_types": ["Membership"],
+            "newsrooms": list(NEWSROOMS),
+        },
+        "supporters": [],
+    }
+
+    frames = []
+    for source, opps in (("donor", donor_opps), ("sponsor", sponsor_opps)):
+        if opps is None or opps.empty:
+            continue
+        frame = opps[COLUMNS].copy()
+        frame["source"] = source
+        frames.append(frame)
+    if not frames:
+        return json.dumps(final)
+
+    opportunities = pd.concat(frames, ignore_index=True)
     opportunities["Amount"] = pd.to_numeric(opportunities["Amount"], errors="coerce")
     opportunities = opportunities.dropna(subset=["Amount"])
     opportunities = opportunities[opportunities["AccountId"] != ""]
@@ -262,57 +293,71 @@ def convert_donors_per_newsroom_over_1k(opportunities, accounts):
     # Belt-and-suspenders against SOQL drift / new picklist values
     opportunities = opportunities[opportunities["Newsroom__c"].isin(NEWSROOMS)]
 
-    # sum opportunity amounts per account per newsroom
-    subtotals = (
-        opportunities.groupby(["AccountId", "Newsroom__c"])["Amount"]
+    # An unparseable CloseDate lands outside the window (NaT fails the
+    # comparison) but still counts toward the all-time total.
+    opportunities["CloseDate"] = pd.to_datetime(
+        opportunities["CloseDate"], errors="coerce"
+    )
+    anchor = pd.Timestamp(as_of) if as_of else pd.Timestamp.utcnow().tz_localize(None)
+    cutoff = anchor.normalize() - pd.Timedelta(days=WINDOW_DAYS)
+
+    keys = ["source", "AccountId", "Newsroom__c"]
+    lifetime = opportunities.groupby(keys)["Amount"].sum()
+    recent = (
+        opportunities[opportunities["CloseDate"] >= cutoff]
+        .groupby(keys)["Amount"]
         .sum()
-        .reset_index()
+        .to_dict()
     )
-    # reorganize to one row per account with a column for each newsroom's
-    # total, including newsrooms with no giving
-    acct_totals_by_newsroom = (
-        subtotals.pivot(index="AccountId", columns="Newsroom__c", values="Amount")
-        .fillna(0)
-        .reindex(columns=list(NEWSROOMS), fill_value=0)
-    )
-    qualifying = acct_totals_by_newsroom[
-        (acct_totals_by_newsroom >= THRESHOLD).any(axis=1)
-    ]
 
-    accounts_dict = accounts.set_index("AccountId")["Text_For_Donor_Wall__c"].to_dict()
+    # Collect the tiers each account cleared, per newsroom. A newsroom the
+    # account cleared nothing in is excluded.
+    tiers = defaultdict(dict)
+    for (source, accountid, newsroom), lifetime_total in lifetime.items():
+        cleared = []
+        if recent.get((source, accountid, newsroom), 0) >= RECENT_THRESHOLD:
+            cleared.append("recent")
+        if lifetime_total >= LIFETIME_THRESHOLD:
+            cleared.append("lifetime")
+        if cleared:
+            tiers[(source, accountid)][newsroom] = cleared
 
-    # check for 'Type' column
+    wall_text = accounts.set_index("AccountId")["Text_For_Donor_Wall__c"].to_dict()
     if "Type" in accounts.columns:
         type_dict = accounts.set_index("AccountId")["Type"].to_dict()
     else:
         type_dict = {}
 
-    donors = []
-    for accountid, row in qualifying.iterrows():
-        raw_attribution = accounts_dict.get(accountid)
-        attribution = None if pd.isna(raw_attribution) else raw_attribution
-        donors.append(
+    supporters = []
+    for (source, accountid), tiers_by_newsroom in tiers.items():
+        raw_attribution = wall_text.get(accountid)
+        supporters.append(
             {
-                "attribution": attribution,
-                "account_type": _safe_account_type(type_dict.get(accountid)),
-                "qualifying_newsrooms": [n for n in NEWSROOMS if row[n] >= THRESHOLD],
-                "totals_by_newsroom": {n: _round_to_int(row[n]) for n in NEWSROOMS},
+                "attribution": None if pd.isna(raw_attribution) else raw_attribution,
+                "source": source,
+                # Sponsor accounts are organizations by definition. Leaving their
+                # account_type null keeps a Household-typed sponsor from being
+                # routed to the consumer's personal-name matching path.
+                "account_type": (
+                    _safe_account_type(type_dict.get(accountid))
+                    if source == "donor"
+                    else None
+                ),
+                "tiers_by_newsroom": {
+                    n: tiers_by_newsroom[n] for n in NEWSROOMS if n in tiers_by_newsroom
+                },
             }
         )
 
-    donors.sort(
-        key=lambda d: (d["attribution"] is None, (d["attribution"] or "").lower())
+    supporters.sort(
+        key=lambda s: (
+            s["attribution"] is None,
+            (s["attribution"] or "").lower(),
+            s["source"],
+        )
     )
 
-    final = {
-        "metadata": {
-            "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "threshold": THRESHOLD,
-            "donor_record_types": ["Membership"],
-            "newsrooms": list(NEWSROOMS),
-        },
-        "donors": donors,
-    }
+    final["supporters"] = supporters
     return json.dumps(final)
 
 
@@ -383,10 +428,6 @@ def _strip_sort_key(the_dict):
             new_list.append(tup[2])
         new_dict[k] = new_list
     return new_dict
-
-
-def _round_to_int(amount):
-    return int(Decimal(str(amount)).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
 
 
 def _safe_account_type(value):

--- a/convert.py
+++ b/convert.py
@@ -249,7 +249,7 @@ def convert_qualified_supporters(donor_opps, sponsor_opps, accounts, as_of=None)
     qualification file, used by the Yellow Lights disclosure check. Compiles 
     sponsors and donors based on whether they hit either or both of these tiers:
 
-        recent    >= $1,000 to that newsroom in the trailing 1,825 days
+        recent    >= $1,000 to that newsroom in the trailing 1,825 days (5 years)
         lifetime  >= $100,000 to that newsroom, all time
 
     Returns a JSON string with shape:
@@ -300,6 +300,10 @@ def convert_qualified_supporters(donor_opps, sponsor_opps, accounts, as_of=None)
     )
     anchor = pd.Timestamp(as_of) if as_of else pd.Timestamp.utcnow().tz_localize(None)
     cutoff = anchor.normalize() - pd.Timedelta(days=WINDOW_DAYS)
+
+    # Drop future close dates from both tiers — that's pledged money that hasn't
+    # arrived. Written as ~(> anchor) so an unparseable date (NaT) is kept.
+    opportunities = opportunities[~(opportunities["CloseDate"] > anchor.normalize())]
 
     keys = ["source", "AccountId", "Newsroom__c"]
     lifetime = opportunities.groupby(keys)["Amount"].sum()

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,6 @@
 import json
 
+import pandas as pd
 from pandas import DataFrame
 
 from convert import (
@@ -9,7 +10,7 @@ from convert import (
     _strip_sort_key,
     clean_url,
     convert_donors,
-    convert_donors_per_newsroom_over_1k,
+    convert_qualified_supporters,
     convert_sponsors,
     make_pretty_money,
 )
@@ -586,194 +587,270 @@ def test_clean_url():
     assert actual == ""
 
 
-def test_convert_donors_per_newsroom_over_1k_basic():
-    """
-    Comprehensive case covering threshold, multi-newsroom qualifying,
-    cumulative-cross-newsroom failure, and defensive filter.
-    """
-    opportunities = DataFrame(
-        {
-            "AccountId":   ["A1",            "A2",            "A3",            "A3",     "A4",            "A4",     "A5"],
-            "Amount":      [1000.0,          999.0,           1000.0,          1500.0,   500.0,           400.0,    1000.0],
-            "Newsroom__c": ["Texas Tribune", "Texas Tribune", "Texas Tribune", "Austin", "Texas Tribune", "Austin", "Bogus"],
-            "CloseDate":   ["2025-03-01"] * 7,
-        }
+# The window is anchored to a fixed past date, not today, so these assertions
+# both stay stable over time and fail if `as_of` is ever ignored.
+AS_OF = "2024-01-15"
+_ANCHOR = pd.Timestamp(AS_OF)
+
+
+def _days_before(days):
+    return (_ANCHOR - pd.Timedelta(days=days)).strftime("%Y-%m-%d")
+
+
+IN_WINDOW = _days_before(30)
+WINDOW_EDGE_IN = _days_before(1825)
+WINDOW_EDGE_OUT = _days_before(1826)
+LONG_AGO = _days_before(3000)
+
+
+def _run(donor_opps=None, sponsor_opps=None, accounts=None):
+    return json.loads(
+        convert_qualified_supporters(
+            donor_opps=donor_opps,
+            sponsor_opps=sponsor_opps,
+            accounts=accounts,
+            as_of=AS_OF,
+        )
     )
-    accounts = DataFrame(
-        {
-            "AccountId": ["A1", "A2", "A3", "A4", "A5"],
-            "Text_For_Donor_Wall__c": ["Donor A1", "Donor A2", "Donor A3", "Donor A4", "Donor A5"],
-        }
-    )
-    actual = json.loads(convert_donors_per_newsroom_over_1k(opportunities, accounts))
-
-    attributions = [d["attribution"] for d in actual["donors"]]
-    assert attributions == ["Donor A1", "Donor A3"]
-
-    a1 = next(d for d in actual["donors"] if d["attribution"] == "Donor A1")
-    assert a1["qualifying_newsrooms"] == ["Texas Tribune"]
-    assert a1["totals_by_newsroom"] == {"Texas Tribune": 1000, "Austin": 0, "Waco Bridge": 0}
-
-    a3 = next(d for d in actual["donors"] if d["attribution"] == "Donor A3")
-    assert a3["qualifying_newsrooms"] == ["Texas Tribune", "Austin"]
-    assert a3["totals_by_newsroom"] == {"Texas Tribune": 1000, "Austin": 1500, "Waco Bridge": 0}
 
 
-def test_convert_donors_per_newsroom_over_1k_below_threshold():
+def test_qualified_supporters_tiers():
     """
-    Donor with $500 Tribune + $400 Austin (cumulative $900) qualifies in
-    NEITHER newsroom — the threshold is per-newsroom, not cumulative.
+    Each tier qualifies on its own, both can apply at once, and an account
+    clearing neither is absent from the file.
     """
-    opportunities = DataFrame(
-        {
-            "AccountId":   ["A1",            "A1"],
-            "Amount":      [500.0,           400.0],
-            "Newsroom__c": ["Texas Tribune", "Austin"],
-            "CloseDate":   ["2025-03-01"] * 2,
-        }
-    )
-    accounts = DataFrame(
-        {
-            "AccountId": ["A1"],
-            "Text_For_Donor_Wall__c": ["Donor A1"],
-        }
-    )
-    actual = json.loads(convert_donors_per_newsroom_over_1k(opportunities, accounts))
-    assert actual["donors"] == []
-
-
-def test_convert_donors_per_newsroom_over_1k_exact_threshold():
-    """
-    $1000 exactly qualifies; $999 does not.
-    """
-    opportunities = DataFrame(
-        {
-            "AccountId":   ["A1",            "A2"],
-            "Amount":      [1000.0,          999.0],
-            "Newsroom__c": ["Texas Tribune", "Texas Tribune"],
-            "CloseDate":   ["2025-03-01"] * 2,
-        }
-    )
-    accounts = DataFrame(
-        {
-            "AccountId": ["A1", "A2"],
-            "Text_For_Donor_Wall__c": ["Donor A1", "Donor A2"],
-        }
-    )
-    actual = json.loads(convert_donors_per_newsroom_over_1k(opportunities, accounts))
-    assert [d["attribution"] for d in actual["donors"]] == ["Donor A1"]
-
-
-def test_convert_donors_per_newsroom_over_1k_defensive_filter():
-    """
-    Row with Newsroom__c outside the canonical three (e.g., a new picklist
-    value or stale data) is silently dropped before aggregation.
-    """
-    opportunities = DataFrame(
-        {
-            "AccountId":   ["A1",            "A2"],
-            "Amount":      [1000.0,          1000.0],
-            "Newsroom__c": ["Texas Tribune", "Bogus"],
-            "CloseDate":   ["2025-03-01"] * 2,
-        }
-    )
-    accounts = DataFrame(
-        {
-            "AccountId": ["A1", "A2"],
-            "Text_For_Donor_Wall__c": ["Donor A1", "Donor A2"],
-        }
-    )
-    actual = json.loads(convert_donors_per_newsroom_over_1k(opportunities, accounts))
-    assert [d["attribution"] for d in actual["donors"]] == ["Donor A1"]
-
-
-def test_convert_donors_per_newsroom_over_1k_metadata_block():
-    """
-    Output's metadata block has the documented shape and values.
-    """
-    opportunities = DataFrame(
-        {
-            "AccountId":   ["A1"],
-            "Amount":      [1000.0],
-            "Newsroom__c": ["Texas Tribune"],
-            "CloseDate":   ["2025-03-01"],
-        }
-    )
-    accounts = DataFrame(
-        {
-            "AccountId": ["A1"],
-            "Text_For_Donor_Wall__c": ["Donor A1"],
-        }
-    )
-    actual = json.loads(convert_donors_per_newsroom_over_1k(opportunities, accounts))
-    metadata = actual["metadata"]
-    assert metadata["threshold"] == 1000
-    assert metadata["donor_record_types"] == ["Membership"]
-    assert metadata["newsrooms"] == ["Texas Tribune", "Austin", "Waco Bridge"]
-    assert metadata["generated_at"].endswith("Z")
-    assert len(metadata["generated_at"]) == 20  # YYYY-MM-DDTHH:MM:SSZ
-
-
-def test_convert_donors_per_newsroom_over_1k_account_type_passthrough():
-    """
-    Account.Type flows through to each donor entry as `account_type`
-    (raw SF value). Step 2 will map this to entity_type per CF1.8.
-    """
-    opportunities = DataFrame(
+    donor_opps = DataFrame(
         {
             "AccountId":   ["A1",            "A2",            "A3",            "A4"],
-            "Amount":      [1000.0,          1000.0,          1000.0,          1000.0],
-            "Newsroom__c": ["Texas Tribune", "Texas Tribune", "Texas Tribune", "Texas Tribune"],
-            "CloseDate":   ["2025-03-01"] * 4,
+            "Amount":      [1000.0,          100000.0,        100000.0,        999.0],
+            "Newsroom__c": ["Texas Tribune"] * 4,
+            "CloseDate":   [IN_WINDOW,       LONG_AGO,        IN_WINDOW,       IN_WINDOW],
         }
     )
     accounts = DataFrame(
         {
             "AccountId": ["A1", "A2", "A3", "A4"],
-            "Text_For_Donor_Wall__c": ["Donor A1", "Donor A2", "Donor A3", "Donor A4"],
-            "Type": ["Household", "Foundation", "Corporate", "Association"],
+            "Text_For_Donor_Wall__c": [
+                "Supporter A1", "Supporter A2", "Supporter A3", "Supporter A4"
+            ],
         }
     )
-    actual = json.loads(convert_donors_per_newsroom_over_1k(opportunities, accounts))
-    by_attr = {d["attribution"]: d for d in actual["donors"]}
-    assert by_attr["Donor A1"]["account_type"] == "Household"
-    assert by_attr["Donor A2"]["account_type"] == "Foundation"
-    assert by_attr["Donor A3"]["account_type"] == "Corporate"
-    assert by_attr["Donor A4"]["account_type"] == "Association"
+    actual = _run(donor_opps=donor_opps, accounts=accounts)
+    by_attr = {s["attribution"]: s for s in actual["supporters"]}
+
+    assert by_attr["Supporter A1"]["tiers_by_newsroom"] == {"Texas Tribune": ["recent"]}
+    assert by_attr["Supporter A2"]["tiers_by_newsroom"] == {"Texas Tribune": ["lifetime"]}
+    assert by_attr["Supporter A3"]["tiers_by_newsroom"] == {
+        "Texas Tribune": ["recent", "lifetime"]
+    }
+    assert "Supporter A4" not in by_attr
 
 
-def test_convert_donors_per_newsroom_over_1k_account_type_missing_or_empty():
+def test_qualified_supporters_exact_thresholds():
     """
-    When the Type column is absent (e.g., older fixtures or SOQL drift) or
-    contains an empty string, account_type is None. Step 2 will default
-    null to 'organization' per CF1.8 §3.
+    Both thresholds are inclusive: exactly $1,000 and exactly $100,000
+    qualify, a dollar under either does not.
     """
-    opportunities = DataFrame(
+    donor_opps = DataFrame(
         {
-            "AccountId":   ["A1"],
+            "AccountId":   ["B1",      "B2",      "B3",      "B4"],
+            "Amount":      [1000.0,    999.0,     100000.0,  99999.0],
+            "Newsroom__c": ["Texas Tribune"] * 4,
+            "CloseDate":   [IN_WINDOW, IN_WINDOW, LONG_AGO,  LONG_AGO],
+        }
+    )
+    accounts = DataFrame(
+        {
+            "AccountId": ["B1", "B2", "B3", "B4"],
+            "Text_For_Donor_Wall__c": [
+                "Supporter B1", "Supporter B2", "Supporter B3", "Supporter B4"
+            ],
+        }
+    )
+    actual = _run(donor_opps=donor_opps, accounts=accounts)
+    assert sorted(s["attribution"] for s in actual["supporters"]) == [
+        "Supporter B1",
+        "Supporter B3",
+    ]
+
+
+def test_qualified_supporters_window_boundary():
+    """
+    An opportunity exactly 1,825 days old is inside the window; 1,826 days is
+    outside it. The out-of-window gift still counts toward the lifetime total,
+    which is why C3 qualifies on the lifetime tier alone.
+    """
+    donor_opps = DataFrame(
+        {
+            "AccountId":   ["C1",            "C2",             "C3"],
+            "Amount":      [1000.0,          1000.0,           100000.0],
+            "Newsroom__c": ["Texas Tribune"] * 3,
+            "CloseDate":   [WINDOW_EDGE_IN,  WINDOW_EDGE_OUT,  WINDOW_EDGE_OUT],
+        }
+    )
+    accounts = DataFrame(
+        {
+            "AccountId": ["C1", "C2", "C3"],
+            "Text_For_Donor_Wall__c": ["Supporter C1", "Supporter C2", "Supporter C3"],
+        }
+    )
+    actual = _run(donor_opps=donor_opps, accounts=accounts)
+    by_attr = {s["attribution"]: s for s in actual["supporters"]}
+
+    assert by_attr["Supporter C1"]["tiers_by_newsroom"] == {"Texas Tribune": ["recent"]}
+    assert "Supporter C2" not in by_attr
+    assert by_attr["Supporter C3"]["tiers_by_newsroom"] == {"Texas Tribune": ["lifetime"]}
+
+
+def test_qualified_supporters_per_newsroom_independence():
+    """
+    Tiers are evaluated per newsroom, never cumulatively across them. D1 clears
+    a different tier in each newsroom; D2's $500 + $600 across two newsrooms
+    clears nothing.
+    """
+    donor_opps = DataFrame(
+        {
+            "AccountId":   ["D1",            "D1",       "D2",            "D2"],
+            "Amount":      [1000.0,          100000.0,   500.0,           600.0],
+            "Newsroom__c": ["Texas Tribune", "Austin",   "Texas Tribune", "Austin"],
+            "CloseDate":   [IN_WINDOW,       LONG_AGO,   IN_WINDOW,       IN_WINDOW],
+        }
+    )
+    accounts = DataFrame(
+        {
+            "AccountId": ["D1", "D2"],
+            "Text_For_Donor_Wall__c": ["Supporter D1", "Supporter D2"],
+        }
+    )
+    actual = _run(donor_opps=donor_opps, accounts=accounts)
+    by_attr = {s["attribution"]: s for s in actual["supporters"]}
+
+    assert by_attr["Supporter D1"]["tiers_by_newsroom"] == {
+        "Texas Tribune": ["recent"],
+        "Austin": ["lifetime"],
+    }
+    assert "Supporter D2" not in by_attr
+
+
+def test_qualified_supporters_donor_and_sponsor_stay_separate():
+    """
+    The same account qualifying as both a donor and a sponsor produces two
+    entries, one per source. Sponsors carry no account_type even when the
+    Salesforce record is a Household — that keeps the consumer from routing a
+    sponsor to its personal-name matching path.
+    """
+    opps = DataFrame(
+        {
+            "AccountId":   ["E1"],
             "Amount":      [1000.0],
             "Newsroom__c": ["Texas Tribune"],
-            "CloseDate":   ["2025-03-01"],
+            "CloseDate":   [IN_WINDOW],
         }
     )
-
-    # No Type column at all
-    accounts_no_col = DataFrame(
+    accounts = DataFrame(
         {
-            "AccountId": ["A1"],
-            "Text_For_Donor_Wall__c": ["Donor A1"],
+            "AccountId": ["E1"],
+            "Text_For_Donor_Wall__c": ["Supporter E1"],
+            "Type": ["Household"],
         }
     )
-    actual = json.loads(convert_donors_per_newsroom_over_1k(opportunities, accounts_no_col))
-    assert actual["donors"][0]["account_type"] is None
+    actual = _run(donor_opps=opps, sponsor_opps=opps.copy(), accounts=accounts)
+    by_source = {s["source"]: s for s in actual["supporters"]}
 
-    # Type column present but empty string
+    assert len(actual["supporters"]) == 2
+    assert by_source["donor"]["attribution"] == "Supporter E1"
+    assert by_source["sponsor"]["attribution"] == "Supporter E1"
+    assert by_source["donor"]["account_type"] == "Household"
+    assert by_source["sponsor"]["account_type"] is None
+
+
+def test_qualified_supporters_defensive_newsroom_filter():
+    """
+    A Newsroom__c value outside the canonical three — new picklist entry, stale
+    data, SOQL drift — is dropped before aggregation.
+    """
+    donor_opps = DataFrame(
+        {
+            "AccountId":   ["F1",            "F2"],
+            "Amount":      [1000.0,          1000.0],
+            "Newsroom__c": ["Texas Tribune", "Bogus"],
+            "CloseDate":   [IN_WINDOW,       IN_WINDOW],
+        }
+    )
+    accounts = DataFrame(
+        {
+            "AccountId": ["F1", "F2"],
+            "Text_For_Donor_Wall__c": ["Supporter F1", "Supporter F2"],
+        }
+    )
+    actual = _run(donor_opps=donor_opps, accounts=accounts)
+    assert [s["attribution"] for s in actual["supporters"]] == ["Supporter F1"]
+
+
+def test_qualified_supporters_account_type_missing_or_empty():
+    """
+    No Type column (older fixtures, SOQL drift) or an empty string yields a null
+    account_type. The consumer defaults null to organization.
+    """
+    donor_opps = DataFrame(
+        {
+            "AccountId":   ["G1"],
+            "Amount":      [1000.0],
+            "Newsroom__c": ["Texas Tribune"],
+            "CloseDate":   [IN_WINDOW],
+        }
+    )
+    accounts_no_col = DataFrame(
+        {"AccountId": ["G1"], "Text_For_Donor_Wall__c": ["Supporter G1"]}
+    )
+    actual = _run(donor_opps=donor_opps, accounts=accounts_no_col)
+    assert actual["supporters"][0]["account_type"] is None
+
     accounts_empty = DataFrame(
         {
-            "AccountId": ["A1"],
-            "Text_For_Donor_Wall__c": ["Donor A1"],
+            "AccountId": ["G1"],
+            "Text_For_Donor_Wall__c": ["Supporter G1"],
             "Type": [""],
         }
     )
-    actual = json.loads(convert_donors_per_newsroom_over_1k(opportunities, accounts_empty))
-    assert actual["donors"][0]["account_type"] is None
+    actual = _run(donor_opps=donor_opps, accounts=accounts_empty)
+    assert actual["supporters"][0]["account_type"] is None
+
+
+def test_qualified_supporters_empty_inputs():
+    """
+    No opportunities on either side returns an empty supporter list with the
+    metadata block intact. walls.py checks this list and skips the S3 push
+    rather than overwriting a good file with an empty one.
+    """
+    actual = _run(accounts=DataFrame())
+    assert actual["supporters"] == []
+    assert actual["metadata"]["window_days"] == 1825
+
+
+def test_qualified_supporters_metadata_block():
+    """
+    Metadata carries the thresholds and window so consumers read the numbers
+    from here rather than inferring them from the tier names.
+    """
+    donor_opps = DataFrame(
+        {
+            "AccountId":   ["H1"],
+            "Amount":      [1000.0],
+            "Newsroom__c": ["Texas Tribune"],
+            "CloseDate":   [IN_WINDOW],
+        }
+    )
+    accounts = DataFrame(
+        {"AccountId": ["H1"], "Text_For_Donor_Wall__c": ["Supporter H1"]}
+    )
+    metadata = _run(donor_opps=donor_opps, accounts=accounts)["metadata"]
+
+    assert metadata["window_days"] == 1825
+    assert metadata["recent_threshold"] == 1000
+    assert metadata["lifetime_threshold"] == 100000
+    assert metadata["in_kind_included"] is True
+    assert metadata["donor_record_types"] == ["Membership"]
+    assert metadata["newsrooms"] == ["Texas Tribune", "Austin", "Waco Bridge"]
+    assert metadata["generated_at"].endswith("Z")
+    assert len(metadata["generated_at"]) == 20  # YYYY-MM-DDTHH:MM:SSZ

--- a/tests.py
+++ b/tests.py
@@ -601,6 +601,8 @@ IN_WINDOW = _days_before(30)
 WINDOW_EDGE_IN = _days_before(1825)
 WINDOW_EDGE_OUT = _days_before(1826)
 LONG_AGO = _days_before(3000)
+FUTURE = _days_before(-365)
+TOMORROW = _days_before(-1)
 
 
 def _run(donor_opps=None, sponsor_opps=None, accounts=None):
@@ -700,6 +702,59 @@ def test_qualified_supporters_window_boundary():
     assert by_attr["Supporter C1"]["tiers_by_newsroom"] == {"Texas Tribune": ["recent"]}
     assert "Supporter C2" not in by_attr
     assert by_attr["Supporter C3"]["tiers_by_newsroom"] == {"Texas Tribune": ["lifetime"]}
+
+
+def test_qualified_supporters_excludes_future_close_dates():
+    """
+    A CloseDate after the run date is pledged money that hasn't arrived, and
+    counts toward neither tier. C4 is a $1,000/yr recurring pledge whose only
+    past installment is $1,000 — it qualifies on that alone, and the two future
+    installments must not lift it into the lifetime tier. C5's single future
+    gift leaves it out of the file entirely.
+    """
+    donor_opps = DataFrame(
+        {
+            "AccountId":   ["C4",       "C4",     "C4",       "C5",      "C6"],
+            "Amount":      [1000.0,     99000.0,  100000.0,   100000.0,  1000.0],
+            "Newsroom__c": ["Texas Tribune"] * 5,
+            "CloseDate":   [IN_WINDOW,  FUTURE,   FUTURE,     FUTURE,    TOMORROW],
+        }
+    )
+    accounts = DataFrame(
+        {
+            "AccountId": ["C4", "C5", "C6"],
+            "Text_For_Donor_Wall__c": ["Supporter C4", "Supporter C5", "Supporter C6"],
+        }
+    )
+    actual = _run(donor_opps=donor_opps, accounts=accounts)
+    by_attr = {s["attribution"]: s for s in actual["supporters"]}
+
+    assert by_attr["Supporter C4"]["tiers_by_newsroom"] == {"Texas Tribune": ["recent"]}
+    assert "Supporter C5" not in by_attr
+    assert "Supporter C6" not in by_attr  # one day out is still out
+
+
+def test_qualified_supporters_undated_gifts_still_count_lifetime():
+    """
+    An unparseable CloseDate is kept, not swept up by the future-date cutoff:
+    it counts toward lifetime (we can't place it in the window) but never
+    toward recent.
+    """
+    donor_opps = DataFrame(
+        {
+            "AccountId":   ["C7"],
+            "Amount":      [100000.0],
+            "Newsroom__c": ["Texas Tribune"],
+            "CloseDate":   [""],
+        }
+    )
+    accounts = DataFrame(
+        {"AccountId": ["C7"], "Text_For_Donor_Wall__c": ["Supporter C7"]}
+    )
+    actual = _run(donor_opps=donor_opps, accounts=accounts)
+    assert actual["supporters"][0]["tiers_by_newsroom"] == {
+        "Texas Tribune": ["lifetime"]
+    }
 
 
 def test_qualified_supporters_per_newsroom_independence():

--- a/walls.py
+++ b/walls.py
@@ -14,7 +14,7 @@ from convert import (
     _sort_circle,
     _strip_sort_key,
     convert_donors,
-    convert_donors_per_newsroom_over_1k,
+    convert_qualified_supporters,
     convert_sponsors,
 )
 from s3 import push_to_s3
@@ -72,7 +72,7 @@ sponsors_query_per_newsroom = """
         AND Newsroom__c IN ('Texas Tribune', 'Austin', 'Waco Bridge')
     """
 
-# Per-newsroom donors — Membership only; $1k threshold applied in Python post-query
+# Per-newsroom donors — Membership only; tier thresholds applied in Python post-query
 donors_query_membership_per_newsroom = """
     SELECT Id, AccountId, Amount, CloseDate, RecordTypeId, Newsroom__c
     FROM Opportunity
@@ -270,27 +270,21 @@ json_output = convert_donors(opportunities=opps, accounts=accts)
 print("Saving donors to S3...")
 push_to_s3(filename="donors.json", contents=json_output)
 
-# Per-newsroom sponsors (3 files: texas-tribune, austin, waco-bridge)
+# Qualified supporters — donors and sponsors in one file, tiered per newsroom.
 print("Fetching per-newsroom sponsor data...")
-opps_pn, accts_pn = sf_data(sponsors_query_per_newsroom)
+sponsor_opps, accts_pn = sf_data(sponsors_query_per_newsroom)
 
-for newsroom_value in ("Texas Tribune", "Austin", "Waco Bridge"):
-    # narrow the all-newsrooms result to this newsroom's opportunities
-    partition = opps_pn[opps_pn["Newsroom__c"] == newsroom_value]
-    file_slug = newsroom_value.lower().replace(" ", "-")
-    print(f"Transforming {newsroom_value} sponsors ({len(partition)} rows)...")
-    if partition.empty:
-        # Skip the push so a transient zero-row result can't clobber a previously
-        # good list. Embeddings Lambda tolerates missing input files.
-        print(f"  no rows for {newsroom_value} — skipping push")
-        continue
-    json_output = convert_sponsors(opportunities=partition, accounts=accts_pn)
-    push_to_s3(filename=f"per-newsroom/{file_slug}-sponsors.json", contents=json_output)
-
-# Per-newsroom donors (1 unified file, >=$1k per-newsroom threshold)
 print("Fetching per-newsroom donor data...")
-opps_pn, accts_pn = sf_data(donors_query_membership_per_newsroom)
-print("Transforming per-newsroom donors...")
-json_output = convert_donors_per_newsroom_over_1k(opportunities=opps_pn, accounts=accts_pn)
-print("Saving per-newsroom donors to S3...")
-push_to_s3(filename="per-newsroom/all-donors-per-newsroom-over-1k.json", contents=json_output)
+donor_opps, _ = sf_data(donors_query_membership_per_newsroom)
+
+print("Transforming qualified supporters...")
+json_output = convert_qualified_supporters(
+    donor_opps=donor_opps, sponsor_opps=sponsor_opps, accounts=accts_pn
+)
+
+# Skip the push on an empty result
+if json.loads(json_output)["supporters"]:
+    print("Saving qualified supporters to S3...")
+    push_to_s3(filename="per-newsroom/qualified-supporters.json", contents=json_output)
+else:
+    print("  no qualifying supporters — skipping push")


### PR DESCRIPTION
## What

Changes who qualifies as a sponsor or donor for the newsroom disclosure check.

Previously: a donor qualified at $1,000 all time; sponsors had no threshold at all, so every sponsor account with a qualifying opportunity was included.

Now, both donors and sponsors are qualified against the same criteria:

| tier | rule |
|---|---|
| `recent` | >= $1,000 to that newsroom in the trailing 1,825 days, and not pledged for the future |
| `lifetime` | >= $100,000 to that newsroom, all time |

To be included in the output, a supporter must be in one or both tiers. The window shifts during every daily run.

**This will significantly reduce the number of sponsors + donors that we flag**. I don't have exact numbers yet, but can report back once this is run against production.

## Output

One new file, `per-newsroom/qualified-supporters.json`:

```json
{
  "metadata": { "window_days": 1825, "recent_threshold": 1000, "lifetime_threshold": 100000, "...": "..." },
  "supporters": [
    {
      "attribution": "Example Foundation",
      "source": "donor",
      "account_type": "Foundation",
      "tiers_by_newsroom": { "Texas Tribune": ["recent"], "Austin": ["recent", "lifetime"] }
    }
  ]
}
```

### How it impacts the older files

This adds a net-new file into the same S3 `per-newsroom` prefix. These four existing files stop being updated, but remain in S3:

- `per-newsroom/all-donors-per-newsroom-over-1k.json`
- `per-newsroom/texas-tribune-sponsors.json`
- `per-newsroom/austin-sponsors.json`
- `per-newsroom/waco-bridge-sponsors.json`

The detection pipeline keeps reading all four successfully, so nothing errors. But once this PR is merged it's running on data frozen as of the last run, until the Sponsor Detection changes (next PR) point it at the new file.

Doesn't touch anything else—only modifies the function made for the initial updates to sponsor/donor detection.

## Testing

To test: pull the branch, start Docker, `make build && make test`. Should have 23 pass.

**tests.py is included in this PR with updated tests, but the primary files to review are convert.py and walls.py**

Covered tests:

- Supporter in all tiers — alone, together, and neither (excluded from the file)
- Thresholds inclusive: exactly $1,000 and exactly $100,000 qualify, a dollar under doesn't
- Window edge: 1,825 days in, 1,826 out — and out-of-window gifts still count toward lifetime
- Per newsroom, never cumulative: $500 + $600 across two newsrooms qualifies nowhere
- One account as both donor and sponsor gives two entries; the sponsor's `account_type` stays null
- Junk `Newsroom__c` dropped, missing/empty `Type` handled, empty input skips the S3 push

Have not tested against production data—but, since this will add a net-new file, can verify once this has been merged (similar approach to the first PR for the new donor detection changes)
